### PR TITLE
Use Github as download source instead of imagemagick.org

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ if [ ! -f $CACHE_FILE ]; then
   IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.xz"
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
   # SSL cert used on imagemagick not recognized by heroku.
-  IMAGE_MAGICK_URL="http://www.imagemagick.org/download/releases/$IMAGE_MAGICK_FILE"
+  IMAGE_MAGICK_URL="https://github.com/ImageMagick/ImageMagick/archive/$IMAGE_MAGICK_FILE"
 
   echo "-----> Downloading ImageMagick from $IMAGE_MAGICK_URL"
   wget $IMAGE_MAGICK_URL -P $BUILD_DIR | indent
@@ -75,7 +75,7 @@ echo "export PATH=$ACTUAL_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
 echo "export LD_LIBRARY_PATH=$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
 echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH" >> $PROFILE_PATH
 
-# DOWNLOAD_URL="http://www.imagemagick.org/download/ImageMagick-7.0.8-25.tar.gz"
+# DOWNLOAD_URL="https://github.com/ImageMagick/ImageMagick/archive/7.0.8-25.tar.gz"
 
 # echo "DOWNLOAD_URL = " $DOWNLOAD_URL | indent
 


### PR DESCRIPTION
It looks like each time a new release is published that the links to the previous version downloads become broken, resulting in a build error for pipeline apps that don't already have a cached ImageMagick installed. I think the Github source here is permanently-accessible so this should allow me to continue using x.25 (or whatever I land on) even as additional releases are published.